### PR TITLE
docs(README): archived notice → LFDT-Minokawa/compact (midnight-iac#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> # ⚠️ This repository is archived
+>
+> `midnightntwrk/compact` only hosted Compact release artifacts and is **no longer maintained**.
+> Active development, issues, and contributions live at
+> **➡️ [LFDT-Minokawa/compact](https://github.com/LFDT-Minokawa/compact)** — the
+> [Linux Foundation Decentralized Trust](https://www.lfdecentralizedtrust.org/) project for Compact.
+>
+> This repo remains read-only for historical release artifacts.
+
 # Compact
 
 Compact is the Midnight Network's smart contract language.


### PR DESCRIPTION
`midnightntwrk/compact` (the releases-host repo) is being **archived** — per midnight-iac#64, routed from servicedesk#50 (reporter @nstanford5). Developers still land here.

Adds a prominent **archived** banner at the top of the README directing them to the active repo: **[LFDT-Minokawa/compact](https://github.com/LFDT-Minokawa/compact)**.

## ⚠️ Merge order
Merge this **before** the archive applies (midnight-iac#78) — once the repo is archived it's read-only and the README can't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)